### PR TITLE
Add Variational Diffusion explainer, colab and fix github link for VDM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ This repository contains a collection of resources and papers on ***Diffusion Mo
 # Resources
 ## Introductory Posts
 
+**A Path to the Variational Diffusion Loss** \
+*Alex Alemi* \
+[[Website]](https://blog.alexalemi.com/diffusion.html) [[Colab]](https://colab.research.google.com/github/google-research/vdm/blob/main/colab/SimpleDiffusionColab.ipynb) \
+15 Sep 2022
+
 **The Annotated Diffusion Model** \
 *Niels Rogge, Kashif Rasul* \
 [[Website](https://huggingface.co/blog/annotated-diffusion)] \
@@ -572,7 +577,7 @@ NeurIPS 2021. [[Paper](https://arxiv.org/abs/2107.03006)] \
 
 **Variational Diffusion Models** \
 *Diederik P. Kingma<sup>1</sup>, Tim Salimans<sup>1</sup>, Ben Poole, Jonathan Ho* \
-arXiv 2021. [[Paper](https://arxiv.org/abs/2107.00630)] [[Github](https://github.com/revsic/jax-variational-diffwave)] \
+arXiv 2021. [[Paper](https://arxiv.org/abs/2107.00630)] [[Github]](https://github.com/google-research/vdm) \
 1 Jul 2021 
 
 **Diffusion Priors In Variational Autoencoders** \


### PR DESCRIPTION
Add blog post and colab explaining variational diffusion as well as fix the associated github link for the paper.