### PR TITLE
fix title, authors, and venue for SDEdit paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1310,9 +1310,9 @@ NeurIPS 2021. [[Paper](https://arxiv.org/abs/2108.08827)] [[Project](https://com
 ICCV 2021 (Oral). [[Paper](https://arxiv.org/abs/2108.02938)] [[Github](https://github.com/jychoi118/ilvr_adm)] \
 6 Aug 2021
 
-**SDEdit: Image Synthesis and Editing with Stochastic Differential Equations** \
-*Chenlin Meng, Yang Song, Jiaming Song, Jiajun Wu, Jun-Yan Zhu, Stefano Ermon* \
-ICLR  2021. [[Paper](https://arxiv.org/abs/2108.01073)] [[Project](https://sde-image-editing.github.io/)] [[Github](https://github.com/ermongroup/SDEdit)] \
+**SDEdit: Guided Image Synthesis and Editing with Stochastic Differential Equations** \
+*Chenlin Meng, Yutong He, Yang Song, Jiaming Song, Jiajun Wu, Jun-Yan Zhu, Stefano Ermon* \
+ICLR  2022. [[Paper](https://arxiv.org/abs/2108.01073)] [[Project](https://sde-image-editing.github.io/)] [[Github](https://github.com/ermongroup/SDEdit)] \
 2 Aug 2021
 
 **Structured Denoising Diffusion Models in Discrete State-Spaces** \


### PR DESCRIPTION
Maybe this paper was changed or re-published after being included in this repo. To make sure, I checked the [ICLR 2021 website](https://iclr.cc/virtual/2021/papers.html?filter=titles&search=sdedit) and did not find the paper, then I checked the [ICLR 2022 website](https://iclr.cc/virtual/2022/papers.html?filter=titles&search=sdedit) and did find it. This PR changes the title, author list, and publication venue to reflect how it was actually published.